### PR TITLE
Fix listener cleanup on unload

### DIFF
--- a/custom_components/smhi_alerts/__init__.py
+++ b/custom_components/smhi_alerts/__init__.py
@@ -31,6 +31,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     unload_ok = await hass.config_entries.async_unload_platforms(entry, ["sensor"])
 
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id, None)
+        # Remove update listener if it was registered
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id, {})
+        update_listener = entry_data.get("update_listener")
+        if update_listener:
+            update_listener()
 
     return unload_ok

--- a/custom_components/smhi_alerts/sensor.py
+++ b/custom_components/smhi_alerts/sensor.py
@@ -37,10 +37,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     # Save coordinator for update listener
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {"coordinator": coordinator}
 
-    # Register listener for options update
-    entry.add_update_listener(async_options_updated)
+    # Register listener for options update and store unsubscribe callback
+    update_listener = entry.add_update_listener(async_options_updated)
+
+    hass.data[DOMAIN][entry.entry_id] = {
+        "coordinator": coordinator,
+        "update_listener": update_listener,
+    }
+
     return True
 
 async def async_options_updated(hass: HomeAssistant, entry: ConfigEntry):


### PR DESCRIPTION
## Summary
- handle cleanup of entry update listeners
- return unsubscribe callback and call it on unload

## Testing
- `python -m compileall custom_components/smhi_alerts`

------
https://chatgpt.com/codex/tasks/task_e_68458e9172b48322ad9867318a91a5c6