### PR TITLE
Fix repository links in manifest

### DIFF
--- a/custom_components/smhi_alerts/manifest.json
+++ b/custom_components/smhi_alerts/manifest.json
@@ -3,9 +3,9 @@
   "name": "SMHI Alert",
   "codeowners": ["@Nicxe"],
   "config_flow": true,
-  "documentation": "https://github.com/Nicxe/home-assistant-smhialert",
+  "documentation": "https://github.com/Nicxe/home-assistant-smhialerts",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/Nicxe/home-assistant-smhialert/issues",
+  "issue_tracker": "https://github.com/Nicxe/home-assistant-smhialerts/issues",
   "version": "1.2.0"
 }
 


### PR DESCRIPTION
## Summary
- update `documentation` and `issue_tracker` links in the manifest to use `home-assistant-smhialerts`

## Testing
- `pip install --quiet homeassistant==2024.4.0`
- `python3 -m script.hassfest /workspace/home-assistant-smhialerts` *(fails: ModuleNotFoundError: No module named 'propcache')*

------
https://chatgpt.com/codex/tasks/task_e_68458e89dc0c83229c28767c9663c2b5