### PR TITLE
Fix options flow deprecation

### DIFF
--- a/custom_components/smhi_alerts/config_flow.py
+++ b/custom_components/smhi_alerts/config_flow.py
@@ -1,4 +1,5 @@
 from homeassistant import config_entries
+from homeassistant.core import callback
 import voluptuous as vol
 from .const import (
     DOMAIN,
@@ -66,15 +67,12 @@ class SmhiAlertsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     @staticmethod
+    @callback
     def async_get_options_flow(config_entry):
-        return SmhiAlertsOptionsFlowHandler(config_entry)
+        return SmhiAlertsOptionsFlowHandler
 
 class SmhiAlertsOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle SMHI Alerts options."""
-
-    def __init__(self, config_entry):
-        """Initialize SMHI Alerts options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""


### PR DESCRIPTION
## Summary
- remove deprecated config_entry argument in options flow
- add callback decorator to options flow entrypoint

## Testing
- `python -m py_compile custom_components/smhi_alerts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68459261d1d08322bebf37e12c3faefb