### PR TITLE
chore: update overrides to fix undici and tar security vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     registries:
       - github-packages
     open-pull-requests-limit: 10

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "home-assistant-smhialerts-temp",
+  "name": "home-assistant-smhialerts",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -46,19 +46,6 @@
         "undici": "^5.28.5"
       }
     },
-    "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/@actions/io": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
@@ -100,16 +87,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@nicxe/semantic-release-config": {
@@ -5671,9 +5648,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.1.tgz",
-      "integrity": "sha512-Gpq0iNm5M6cQWlyHQv9MV+uOj1jWk7LpkoE5vSp/7zjb4zMdAcUD+VL5y0nH4p9EbUklq00eVIIX/XcDHzu5xg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "semantic-release": "^25.0.3"
   },
   "overrides": {
-    "tar": ">=7.5.8",
+    "tar": "^7.5.11",
     "npm": ">=11.10.1",
     "cross-spawn": "^7.0.6",
-    "brace-expansion": "^2.0.2"
+    "brace-expansion": "^2.0.2",
+    "undici": ">=7.24.0"
   }
 }


### PR DESCRIPTION
Updates the `overrides` section in package.json to address known security vulnerabilities. The `tar` override has been tightened from `>=7.5.8` to `^7.5.11`, and `undici` has been added at `>=7.24.0`. The package-lock.json has been regenerated accordingly.