### PR TITLE
chore: Resolve open dependency security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "home-assistant-smhialerts",
       "devDependencies": {
         "@nicxe/semantic-release-config": "^1.2.3",
         "@semantic-release/commit-analyzer": "^13.0.0",
@@ -2353,9 +2352,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.17.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
-      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz",
+      "integrity": "sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -2434,8 +2433,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.8.0",
-        "@npmcli/config": "^10.11.0",
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/config": "^10.12.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -2459,11 +2458,11 @@
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.10",
-        "libnpmexec": "^10.3.0",
-        "libnpmfund": "^7.0.24",
+        "libnpmdiff": "^8.1.11",
+        "libnpmexec": "^10.3.1",
+        "libnpmfund": "^7.0.25",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.10",
+        "libnpmpack": "^9.1.11",
         "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -2479,7 +2478,7 @@
         "npm-install-checks": "^8.0.0",
         "npm-package-arg": "^13.0.2",
         "npm-pick-manifest": "^11.0.3",
-        "npm-profile": "^12.0.1",
+        "npm-profile": "^12.0.2",
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
@@ -2488,11 +2487,11 @@
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.8.4",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.16",
+        "tar": "^7.5.19",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -2581,7 +2580,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.8.0",
+      "version": "9.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2629,7 +2628,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.11.0",
+      "version": "10.12.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2974,7 +2973,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3348,12 +3347,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.10",
+      "version": "8.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -3367,13 +3366,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.3.0",
+      "version": "10.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -3390,12 +3389,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.24",
+      "version": "7.0.25",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0"
+        "@npmcli/arborist": "^9.9.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -3415,12 +3414,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.10",
+      "version": "9.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -3789,13 +3788,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "12.0.1",
+      "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0"
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -4000,7 +3999,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.8.4",
+      "version": "7.8.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4125,7 +4124,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.16",
+      "version": "7.5.19",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -4221,7 +4220,7 @@
       }
     },
     "node_modules/npm/node_modules/undici": {
-      "version": "6.26.0",
+      "version": "6.27.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "overrides": {
     "tar": "^7.5.11",
-    "npm": ">=11.17.0",
+    "npm": ">=11.18.0",
     "cross-spawn": "^7.0.6",
     "brace-expansion": "^2.0.2",
     "undici": ">=7.24.0",


### PR DESCRIPTION
Raises the npm override to 11.18.0 and refreshes the lockfile. This moves bundled undici from 6.26.0 to patched 6.27.0 and resolves the three open development-scope Dependabot alerts.

Validation completed with `npm ci --ignore-scripts --no-audit --no-fund` and `npm audit`, which reports zero vulnerabilities.