### PR TITLE
chore: update vulnerable bundled dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3303,7 +3303,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.2.0",
+      "version": "10.3.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4276,7 +4276,7 @@
       }
     },
     "node_modules/npm/node_modules/undici": {
-      "version": "6.27.0",
+      "version": "6.28.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",


### PR DESCRIPTION
## Summary
- update npm's bundled `ip-address` lockfile entry from 10.2.0 to 10.3.1
- update npm's bundled `undici` lockfile entry from 6.27.0 to 6.28.0
- keep the security fix limited to the two vulnerable lockfile entries

## Validation
- `npm ci`
- `node --experimental-default-type=module --check custom_components/smhi_alerts/www/smhi-alert-card.js`
- `npm audit --json` no longer reports `ip-address` or `undici` (5 unrelated findings remain: 1 high, 4 moderate)
- Python test suite was not run locally because `pytest` is not installed in the environment; repository CI provides integration validation

## Risk
Low. This changes only bundled transitive dependency versions recorded in `package-lock.json`; no runtime integration code is changed.